### PR TITLE
`gfortran` build for the Mac OS

### DIFF
--- a/3PGN_SpringSchool/Compile and Run 3PG.r
+++ b/3PGN_SpringSchool/Compile and Run 3PG.r
@@ -17,7 +17,7 @@
 #' Build the library pasting in the terminal the following string
 
 R CMD SHLIB -o 3PG src/declarations.f90 src/routines.f90 src/model.f90 src/init_model.f90 src/initbc.f90 src/changepars.f90
-#' 
+#' gfortran -shared  -fPIC -o 3PG src/declarations.f90 src/routines.f90 src/model.f90 src/init_model.f90 src/initbc.f90 src/changepars.f90
 #' 
 
 #' Load library and first model run


### PR DESCRIPTION
@checcomi I had to use the `gfortan` build for the Mac OS, otherwise by using the previous version of `R CMD SHLIB...` it was complaining e.g. `ignoring file src/init_model.o, file was built for unsupported file format ( 0x64 0x86 0x05 0x00 0x00 0x00 0x00 0x00 0x94 0x01 0x00 0x00 0x13 0x00 0x00 0x00 ) which is not the architecture being linked (x86_64)`